### PR TITLE
Fix bug: prevent valid translations from being discarded in mixed content

### DIFF
--- a/internal/service/audio2subtitle.go
+++ b/internal/service/audio2subtitle.go
@@ -981,26 +981,6 @@ func parseAndCheckContent(splitContent, originalText string) ([]TranslatedItem, 
 		}
 	}
 
-	// 处理无文本标记
-	if strings.Contains(splitContent, "[无文本]") {
-		// 检查原始文本是否是音乐标记或类似内容
-		lowerOriginal := strings.ToLower(strings.TrimSpace(originalText))
-		if len(lowerOriginal) < 30 && (strings.Contains(lowerOriginal, "music") ||
-			strings.Contains(lowerOriginal, "playing") ||
-			strings.Contains(lowerOriginal, "♪") ||
-			strings.Contains(lowerOriginal, "♫") ||
-			len(lowerOriginal) < 10) {
-			// 如果原始文本是音乐标记或很短，则返回空结果
-			return result, nil
-		} else {
-			// 记录警告但不返回错误，允许处理继续
-			log.GetLogger().Warn("originalText might contain actual content but splitContent contains [无文本]",
-				zap.String("originalText", originalText),
-				zap.String("splitContent", splitContent))
-			return result, nil
-		}
-	}
-
 	lines := strings.Split(splitContent, "\n")
 	if len(lines) < 3 { // 至少需要一个完整的块
 		log.GetLogger().Error("audioToSubtitle invaild Format, not enough lines", zap.Any("splitContent", splitContent))
@@ -1030,6 +1010,13 @@ func parseAndCheckContent(splitContent, originalText string) ([]TranslatedItem, 
 		originalLine := strings.TrimSpace(lines[i+2])
 		originalLine = strings.TrimPrefix(originalLine, "[")
 		originalLine = strings.TrimSuffix(originalLine, "]")
+		
+		// 跳过无文本块
+		if translatedLine == "无文本" || originalLine == "无文本" {
+			i += 2 // 跳过这个块
+			continue
+		}
+		
 		result = append(result, TranslatedItem{
 			OriginText:     originalLine,
 			TranslatedText: translatedLine,

--- a/pkg/util/base.go
+++ b/pkg/util/base.go
@@ -193,11 +193,11 @@ func CopyFile(src, dst string) error {
 func SanitizePathName(name string) string {
 	var illegalChars *regexp.Regexp
 	if runtime.GOOS == "windows" {
-		// Windows 特殊字符
-		illegalChars = regexp.MustCompile(`[<>:"/\\|?*\x00-\x1F]`)
+		// Windows 特殊字符，包括方括号（会影响 filepath.Glob）
+		illegalChars = regexp.MustCompile(`[<>:"/\\|?*\[\]\x00-\x1F]`)
 	} else {
-		// POSIX 系统：只禁用 / 和空字节
-		illegalChars = regexp.MustCompile(`[/\x00]`)
+		// POSIX 系统：禁用 /、空字节和方括号（会影响 filepath.Glob）
+		illegalChars = regexp.MustCompile(`[/\[\]\x00]`)
 	}
 
 	sanitized := illegalChars.ReplaceAllString(name, "_")


### PR DESCRIPTION
2 bugs fix：
1.  it report error when video path name has []
2.  prevent valid translations from being discarded when only few sentences of `splitContent` is "[无文本]"