### PR TITLE
fix(handler): restrict file downloads to tasks directory — prevent API key leakage

### DIFF
--- a/internal/handler/subtitle_task.go
+++ b/internal/handler/subtitle_task.go
@@ -6,8 +6,10 @@ import (
 	"krillin-ai/internal/response"
 	"krillin-ai/internal/service"
 	"krillin-ai/log"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 	"go.uber.org/zap"
@@ -141,6 +143,20 @@ func (h Handler) DownloadFile(c *gin.Context) {
 	}
 
 	localFilePath := filepath.Join(".", requestedFile)
+
+	// Restrict downloads to the tasks output directory to prevent
+	// arbitrary file reads (e.g. config/config.toml with API keys).
+	tasksDir, err := filepath.Abs("tasks")
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": "内部错误"})
+		return
+	}
+	absPath, err := filepath.Abs(localFilePath)
+	if err != nil || !strings.HasPrefix(absPath, tasksDir+string(os.PathSeparator)) {
+		c.JSON(http.StatusForbidden, gin.H{"error": "禁止访问"})
+		return
+	}
+
 	if _, err := os.Stat(localFilePath); os.IsNotExist(err) {
 		response.R(c, response.Response{
 			Error: -1,


### PR DESCRIPTION
## Summary

The `DownloadFile` handler in `internal/handler/subtitle_task.go` accepts arbitrary file paths via the `*filepath` route parameter and serves them with no directory restriction.

**Root cause:** `filepath.Join(".", requestedFile)` resolves absolute paths by design — `filepath.Join(".", "/config/config.toml")` returns `"config/config.toml"`, not an error. Any caller can read any file the process can read.

**Impact:** The `config/config.toml` file typically contains API keys for OpenAI, Anthropic, Deepseek, ElevenLabs, and similar services. A single GET request leaks all of them:

```
GET /api/file/config/config.toml
```

**Fix:** Resolve both the requested path and the `tasks/` output directory to absolute paths, then reject requests that don't start with the tasks directory prefix (HTTP 403).

```go
tasksDir, err := filepath.Abs("tasks")
// ...
absPath, err := filepath.Abs(localFilePath)
if err != nil || !strings.HasPrefix(absPath, tasksDir+string(os.PathSeparator)) {
    c.JSON(http.StatusForbidden, gin.H{"error": "禁止访问"})
    return
}
```

This was found during a security-focused review of the file download endpoint.

## Test plan

- [ ] `GET /api/file/tasks/<valid-output-file>` → 200, file served
- [ ] `GET /api/file/config/config.toml` → 403 Forbidden
- [ ] `GET /api/file/../config/config.toml` → 403 Forbidden
- [ ] `GET /api/file//etc/passwd` → 403 Forbidden