### PR TITLE
feat: add MiniMax as a TTS provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ _**All local models in the table below support automatic installation of executa
 
 - Alibaba Cloud Voice Service
 - OpenAI TTS
+- MiniMax TTS
 
 ## Language Support
 

--- a/config/config-example.toml
+++ b/config/config-example.toml
@@ -47,11 +47,15 @@
             app_key= ""
 
 [tts]
-    provider = "aliyun" # 可选值：openai,aliyun,edge-tts
+    provider = "aliyun" # 可选值：openai,aliyun,edge-tts,minimax
     [tts.openai]
         base_url = ""
         api_key = ""
         model = "" # gpt-4o-mini-tts, tts-1, tts-1-hd
+    [tts.minimax] # MiniMax TTS(T2A v2),provider选minimax时填写
+        base_url = "" # 留空默认海外版 https://api.minimax.io，国内可填 https://api.minimaxi.com
+        api_key = "" # MiniMax API密钥
+        model = "" # 留空默认 speech-2.8-hd，可选 speech-2.8-turbo, speech-2.6-hd, speech-2.6-turbo
     [tts.aliyun] # provider选aliyun这块就都要填
         [tts.aliyun.oss]
             access_key_id = ""

--- a/config/config.go
+++ b/config/config.go
@@ -81,6 +81,7 @@ type Tts struct {
 	Provider string                 `toml:"provider"`
 	Openai   OpenaiCompatibleConfig `toml:"openai"`
 	Aliyun   AliyunTtsConfig        `toml:"aliyun"`
+	Minimax  OpenaiCompatibleConfig `toml:"minimax"`
 }
 
 type Dubbing struct {

--- a/internal/cli/commands.go
+++ b/internal/cli/commands.go
@@ -208,7 +208,7 @@ Flags:
   krillinai-cli voices [flags]
 
 Flags:
-  --provider <name>  TTS provider to list voices for: aliyun, openai, or edge-tts; default current config
+  --provider <name>  TTS provider to list voices for: aliyun, openai, minimax, or edge-tts; default current config
   --dry-run          Return the same local voice list without external calls
   -h, --help         Show this help
 `

--- a/internal/desktop/ui.go
+++ b/internal/desktop/ui.go
@@ -698,7 +698,7 @@ func createTranscribeConfigGroup() *fyne.Container {
 
 // 创建文本转语音配置组
 func createTtsConfigGroup() *fyne.Container {
-	providerOptions := []string{"openai", "aliyun", "edge-tts"}
+	providerOptions := []string{"openai", "aliyun", "edge-tts", "minimax"}
 	providerSelect := widget.NewSelect(providerOptions, func(value string) {
 		config.Conf.Tts.Provider = value
 	})
@@ -710,6 +710,13 @@ func createTtsConfigGroup() *fyne.Container {
 	openaiApiKeyEntry.Bind(binding.BindString(&config.Conf.Tts.Openai.ApiKey))
 	openaiModelEntry := StyledEntry("模型名称 Model name")
 	openaiModelEntry.Bind(binding.BindString(&config.Conf.Tts.Openai.Model))
+
+	minimaxBaseUrlEntry := StyledEntry("API Base URL")
+	minimaxBaseUrlEntry.Bind(binding.BindString(&config.Conf.Tts.Minimax.BaseUrl))
+	minimaxApiKeyEntry := StyledPasswordEntry("API Key")
+	minimaxApiKeyEntry.Bind(binding.BindString(&config.Conf.Tts.Minimax.ApiKey))
+	minimaxModelEntry := StyledEntry("模型名称 Model name")
+	minimaxModelEntry.Bind(binding.BindString(&config.Conf.Tts.Minimax.Model))
 
 	aliyunOssKeyIdEntry := StyledEntry("阿里云 Aliyun Access Key ID")
 	aliyunOssKeyIdEntry.Bind(binding.BindString(&config.Conf.Tts.Aliyun.Oss.AccessKeyId))
@@ -731,6 +738,10 @@ func createTtsConfigGroup() *fyne.Container {
 		widget.NewFormItem("OpenAI Base URL", openaiBaseUrlEntry),
 		widget.NewFormItem("OpenAI API Key", openaiApiKeyEntry),
 		widget.NewFormItem("OpenAI 模型 Model", openaiModelEntry),
+
+		widget.NewFormItem("MiniMax Base URL", minimaxBaseUrlEntry),
+		widget.NewFormItem("MiniMax API Key", minimaxApiKeyEntry),
+		widget.NewFormItem("MiniMax 模型 Model", minimaxModelEntry),
 
 		widget.NewFormItem("阿里云 Aliyun OSS Access Key ID", aliyunOssKeyIdEntry),
 		widget.NewFormItem("阿里云 Aliyun OSS Access Key Secret", aliyunOssKeySecretEntry),

--- a/internal/service/init.go
+++ b/internal/service/init.go
@@ -8,6 +8,7 @@ import (
 	"krillin-ai/pkg/fasterwhisper"
 	pkgimage "krillin-ai/pkg/image"
 	"krillin-ai/pkg/localtts"
+	"krillin-ai/pkg/minimax"
 	"krillin-ai/pkg/openai"
 	"krillin-ai/pkg/whisper"
 	"krillin-ai/pkg/whispercpp"
@@ -59,6 +60,8 @@ func NewService() *Service {
 		ttsClient = aliyun.NewTtsClient(config.Conf.Tts.Aliyun.Speech.AccessKeyId, config.Conf.Tts.Aliyun.Speech.AccessKeySecret, config.Conf.Tts.Aliyun.Speech.AppKey)
 	case "edge-tts":
 		ttsClient = localtts.NewEdgeTtsClient()
+	case "minimax":
+		ttsClient = minimax.NewTtsClient(config.Conf.Tts.Minimax.BaseUrl, config.Conf.Tts.Minimax.ApiKey, config.Conf.Tts.Minimax.Model)
 	}
 
 	s := &Service{

--- a/internal/voices/voices.go
+++ b/internal/voices/voices.go
@@ -12,6 +12,7 @@ const (
 	ProviderAliyun = "aliyun"
 	ProviderOpenAI = "openai"
 	ProviderEdge   = "edge-tts"
+	Minimax        = "minimax"
 )
 
 func List(provider string) ([]pipeline.Voice, error) {
@@ -21,6 +22,8 @@ func List(provider string) ([]pipeline.Voice, error) {
 		return cloneVoices(aliyunVoices), nil
 	case ProviderOpenAI:
 		return cloneVoices(openaiVoices), nil
+	case Minimax:
+		return cloneVoices(minimaxVoices), nil
 	case ProviderEdge:
 		return nil, fmt.Errorf("edge-tts voice listing is not supported yet; use edge-tts --list-voices")
 	default:
@@ -29,7 +32,7 @@ func List(provider string) ([]pipeline.Voice, error) {
 }
 
 func Providers() []string {
-	return []string{ProviderAliyun, ProviderOpenAI, ProviderEdge}
+	return []string{ProviderAliyun, ProviderOpenAI, Minimax, ProviderEdge}
 }
 
 func cloneVoices(in []pipeline.Voice) []pipeline.Voice {
@@ -67,4 +70,13 @@ var openaiVoices = []pipeline.Voice{
 	{Provider: ProviderOpenAI, Code: "onyx", Language: "multi", Scenario: "deep"},
 	{Provider: ProviderOpenAI, Code: "sage", Language: "multi", Scenario: "neutral"},
 	{Provider: ProviderOpenAI, Code: "shimmer", Language: "multi", Scenario: "soft"},
+}
+
+var minimaxVoices = []pipeline.Voice{
+	{Provider: Minimax, Code: "English_Graceful_Lady", Name: "Graceful Lady", Language: "en", Gender: "female", Scenario: "优雅女声"},
+	{Provider: Minimax, Code: "English_radiant_girl", Name: "Radiant Girl", Language: "en", Gender: "female", Scenario: "活泼女声"},
+	{Provider: Minimax, Code: "English_Insightful_Speaker", Name: "Insightful Speaker", Language: "en", Gender: "male", Scenario: "沉稳男声"},
+	{Provider: Minimax, Code: "English_Persuasive_Man", Name: "Persuasive Man", Language: "en", Gender: "male", Scenario: "有说服力男声"},
+	{Provider: Minimax, Code: "English_expressive_narrator", Name: "Expressive Narrator", Language: "en", Gender: "male", Scenario: "旁白"},
+	{Provider: Minimax, Code: "English_Lucky_Robot", Name: "Lucky Robot", Language: "en", Gender: "neutral", Scenario: "机器人"},
 }

--- a/internal/voices/voices_test.go
+++ b/internal/voices/voices_test.go
@@ -29,6 +29,37 @@ func TestListRejectsUnsupportedProvider(t *testing.T) {
 	}
 }
 
+func TestListMinimaxVoices(t *testing.T) {
+	got, err := List(Minimax)
+	if err != nil {
+		t.Fatalf("List() error = %v", err)
+	}
+	if !hasVoice(got, "English_Graceful_Lady") {
+		t.Fatalf("minimax voices = %#v, want English_Graceful_Lady", got)
+	}
+	if !hasVoice(got, "English_radiant_girl") {
+		t.Fatalf("minimax voices = %#v, want English_radiant_girl", got)
+	}
+	for _, v := range got {
+		if v.Provider != Minimax {
+			t.Fatalf("voice %q provider = %q, want %q", v.Code, v.Provider, Minimax)
+		}
+	}
+}
+
+func TestProvidersIncludesMinimax(t *testing.T) {
+	found := false
+	for _, p := range Providers() {
+		if p == Minimax {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("Providers() = %#v, want to include %q", Providers(), Minimax)
+	}
+}
+
 func hasVoice(voices []pipeline.Voice, code string) bool {
 	for _, voice := range voices {
 		if voice.Code == code {

--- a/pkg/minimax/tts.go
+++ b/pkg/minimax/tts.go
@@ -1,0 +1,195 @@
+package minimax
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"krillin-ai/config"
+	"krillin-ai/log"
+
+	"go.uber.org/zap"
+)
+
+const (
+	// DefaultBaseUrl 海外版地址，国内可改用 https://api.minimaxi.com
+	DefaultBaseUrl = "https://api.minimax.io"
+	// DefaultModel 推荐默认 TTS 模型，音色相似度最高
+	DefaultModel = "speech-2.8-hd"
+	// DefaultVoice 当未指定音色时使用的默认音色
+	DefaultVoice = "English_Graceful_Lady"
+)
+
+// TtsClient 调用 MiniMax T2A v2 文本转语音接口，实现 types.Ttser。
+type TtsClient struct {
+	BaseUrl    string
+	ApiKey     string
+	Model      string
+	httpClient *http.Client
+}
+
+// NewTtsClient 创建 MiniMax TTS 客户端，空参数回退到默认值。
+func NewTtsClient(baseUrl, apiKey, model string) *TtsClient {
+	baseUrl = strings.TrimRight(strings.TrimSpace(baseUrl), "/")
+	if baseUrl == "" {
+		baseUrl = DefaultBaseUrl
+	}
+	if strings.TrimSpace(model) == "" {
+		model = DefaultModel
+	}
+
+	transport := &http.Transport{}
+	if config.Conf.App.Proxy != "" && config.Conf.App.ParsedProxy != nil {
+		transport.Proxy = http.ProxyURL(config.Conf.App.ParsedProxy)
+	}
+
+	return &TtsClient{
+		BaseUrl: baseUrl,
+		ApiKey:  apiKey,
+		Model:   model,
+		httpClient: &http.Client{
+			Timeout:   60 * time.Second,
+			Transport: transport,
+		},
+	}
+}
+
+type voiceSetting struct {
+	VoiceID string  `json:"voice_id"`
+	Speed   float64 `json:"speed"`
+	Vol     float64 `json:"vol"`
+	Pitch   int     `json:"pitch"`
+}
+
+type audioSetting struct {
+	SampleRate int    `json:"sample_rate"`
+	Format     string `json:"format"`
+	Channel    int    `json:"channel"`
+}
+
+type t2aRequest struct {
+	Model        string       `json:"model"`
+	Text         string       `json:"text"`
+	Stream       bool         `json:"stream"`
+	VoiceSetting voiceSetting `json:"voice_setting"`
+	AudioSetting audioSetting `json:"audio_setting"`
+}
+
+type t2aResponse struct {
+	Data struct {
+		Audio  string `json:"audio"`
+		Status int    `json:"status"`
+	} `json:"data"`
+	BaseResp struct {
+		StatusCode int    `json:"status_code"`
+		StatusMsg  string `json:"status_msg"`
+	} `json:"base_resp"`
+}
+
+// buildRequestBody 组装非流式 T2A v2 请求体，输出 wav 以匹配下游配音流程。
+func (c *TtsClient) buildRequestBody(text, voice string) ([]byte, error) {
+	voice = strings.TrimSpace(voice)
+	if voice == "" {
+		voice = DefaultVoice
+	}
+	reqBody := t2aRequest{
+		Model:  c.Model,
+		Text:   text,
+		Stream: false,
+		VoiceSetting: voiceSetting{
+			VoiceID: voice,
+			Speed:   1,
+			Vol:     1,
+			Pitch:   0,
+		},
+		AudioSetting: audioSetting{
+			SampleRate: 44100,
+			Format:     "wav",
+			Channel:    1,
+		},
+	}
+	return json.Marshal(reqBody)
+}
+
+// decodeAudio 解析非流式响应，校验业务状态码后将 hex 音频解码为字节。
+func decodeAudio(respBody []byte) ([]byte, error) {
+	var parsed t2aResponse
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return nil, fmt.Errorf("minimax tts decode response failed: %w", err)
+	}
+	if parsed.BaseResp.StatusCode != 0 {
+		return nil, fmt.Errorf("minimax tts api error: status_code=%d, status_msg=%s", parsed.BaseResp.StatusCode, parsed.BaseResp.StatusMsg)
+	}
+	if parsed.Data.Audio == "" {
+		return nil, fmt.Errorf("minimax tts api returned empty audio")
+	}
+	// MiniMax 返回 hex 编码音频（非 base64）
+	audio, err := hex.DecodeString(parsed.Data.Audio)
+	if err != nil {
+		return nil, fmt.Errorf("minimax tts hex decode failed: %w", err)
+	}
+	return audio, nil
+}
+
+// Text2Speech 将文本合成为语音并写入 outputFile（wav）。
+func (c *TtsClient) Text2Speech(text, voice, outputFile string) error {
+	if c.ApiKey == "" {
+		return fmt.Errorf("minimax tts api key is empty")
+	}
+
+	body, err := c.buildRequestBody(text, voice)
+	if err != nil {
+		return fmt.Errorf("minimax tts build request failed: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 60*time.Second)
+	defer cancel()
+
+	url := c.BaseUrl + "/v1/t2a_v2"
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Authorization", "Bearer "+c.ApiKey)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		log.GetLogger().Error("minimax tts request failed", zap.Error(err))
+		return err
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusOK {
+		log.GetLogger().Error("minimax tts non-200 status", zap.Int("status_code", resp.StatusCode), zap.String("body", string(respBody)))
+		return fmt.Errorf("minimax tts none-200 status code: %d", resp.StatusCode)
+	}
+
+	audio, err := decodeAudio(respBody)
+	if err != nil {
+		log.GetLogger().Error("minimax tts decode audio failed", zap.Error(err))
+		return err
+	}
+
+	outputDir := filepath.Dir(outputFile)
+	if err = os.MkdirAll(outputDir, 0755); err != nil {
+		return fmt.Errorf("minimax tts create output dir failed: %w", err)
+	}
+	if err = os.WriteFile(outputFile, audio, 0644); err != nil {
+		return fmt.Errorf("minimax tts write output file failed: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/minimax/tts_test.go
+++ b/pkg/minimax/tts_test.go
@@ -1,0 +1,112 @@
+package minimax
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewTtsClientDefaults(t *testing.T) {
+	c := NewTtsClient("", "key", "")
+	if c.BaseUrl != DefaultBaseUrl {
+		t.Fatalf("BaseUrl = %q, want %q", c.BaseUrl, DefaultBaseUrl)
+	}
+	if c.Model != DefaultModel {
+		t.Fatalf("Model = %q, want %q", c.Model, DefaultModel)
+	}
+}
+
+func TestNewTtsClientTrimsTrailingSlash(t *testing.T) {
+	c := NewTtsClient("https://api.minimaxi.com/", "key", "speech-2.6-hd")
+	if c.BaseUrl != "https://api.minimaxi.com" {
+		t.Fatalf("BaseUrl = %q, want trailing slash trimmed", c.BaseUrl)
+	}
+	if c.Model != "speech-2.6-hd" {
+		t.Fatalf("Model = %q, want speech-2.6-hd", c.Model)
+	}
+}
+
+func TestBuildRequestBody(t *testing.T) {
+	c := NewTtsClient("", "key", "")
+	body, err := c.buildRequestBody("hello world", "")
+	if err != nil {
+		t.Fatalf("buildRequestBody() error = %v", err)
+	}
+
+	var req t2aRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal request body failed: %v", err)
+	}
+	if req.Model != DefaultModel {
+		t.Fatalf("model = %q, want %q", req.Model, DefaultModel)
+	}
+	if req.Text != "hello world" {
+		t.Fatalf("text = %q, want hello world", req.Text)
+	}
+	if req.Stream {
+		t.Fatal("stream = true, want false for file output")
+	}
+	if req.VoiceSetting.VoiceID != DefaultVoice {
+		t.Fatalf("voice_id = %q, want default %q", req.VoiceSetting.VoiceID, DefaultVoice)
+	}
+	if req.AudioSetting.Format != "wav" {
+		t.Fatalf("audio format = %q, want wav", req.AudioSetting.Format)
+	}
+}
+
+func TestBuildRequestBodyCustomVoice(t *testing.T) {
+	c := NewTtsClient("", "key", "")
+	body, err := c.buildRequestBody("hi", "  English_radiant_girl  ")
+	if err != nil {
+		t.Fatalf("buildRequestBody() error = %v", err)
+	}
+	var req t2aRequest
+	if err := json.Unmarshal(body, &req); err != nil {
+		t.Fatalf("unmarshal request body failed: %v", err)
+	}
+	if req.VoiceSetting.VoiceID != "English_radiant_girl" {
+		t.Fatalf("voice_id = %q, want trimmed English_radiant_girl", req.VoiceSetting.VoiceID)
+	}
+}
+
+func TestDecodeAudioSuccess(t *testing.T) {
+	// "ID3" 头的 hex 表示
+	want := []byte("ID3test")
+	hexAudio := hex.EncodeToString(want)
+	resp := []byte(`{"data":{"audio":"` + hexAudio + `","status":2},"base_resp":{"status_code":0,"status_msg":"success"}}`)
+
+	got, err := decodeAudio(resp)
+	if err != nil {
+		t.Fatalf("decodeAudio() error = %v", err)
+	}
+	if string(got) != string(want) {
+		t.Fatalf("decoded audio = %q, want %q", got, want)
+	}
+}
+
+func TestDecodeAudioApiError(t *testing.T) {
+	resp := []byte(`{"data":{"audio":"","status":0},"base_resp":{"status_code":2013,"status_msg":"invalid params"}}`)
+	if _, err := decodeAudio(resp); err == nil {
+		t.Fatal("decodeAudio() error = nil, want api error")
+	}
+}
+
+func TestDecodeAudioEmpty(t *testing.T) {
+	resp := []byte(`{"data":{"audio":"","status":2},"base_resp":{"status_code":0,"status_msg":"success"}}`)
+	if _, err := decodeAudio(resp); err == nil {
+		t.Fatal("decodeAudio() error = nil, want empty audio error")
+	}
+}
+
+func TestText2SpeechRequiresApiKey(t *testing.T) {
+	c := NewTtsClient("", "", "")
+	out := filepath.Join(t.TempDir(), "out.wav")
+	if err := c.Text2Speech("hello", "", out); err == nil {
+		t.Fatal("Text2Speech() error = nil, want missing api key error")
+	}
+	if _, err := os.Stat(out); err == nil {
+		t.Fatal("output file written despite missing api key")
+	}
+}


### PR DESCRIPTION
## Summary

Add **MiniMax** (T2A v2) as a new selectable Text-to-Speech provider, alongside the existing `openai`, `aliyun`, and `edge-tts` options. MiniMax's speech API is not OpenAI-compatible (it uses the `/v1/t2a_v2` endpoint with hex-encoded audio), so it needs a dedicated client rather than reusing the OpenAI TTS path.

## Changes

- Add `pkg/minimax` TTS client implementing the existing `types.Ttser` interface. It calls `POST /v1/t2a_v2`, checks `base_resp.status_code`, decodes the **hex-encoded** audio, and writes `wav` output to match what the dubbing pipeline probes.
- Wire `minimax` into the TTS provider switch in `internal/service/init.go`.
- Add a `[tts.minimax]` config block (`base_url` / `api_key` / `model`), defaulting to the overseas base URL `https://api.minimax.io` and model `speech-2.8-hd`.
- Register MiniMax voices in `internal/voices` so they show up in the voices list and `krillinai-cli voices --provider minimax`.
- Add the provider to the desktop TTS config form.
- Document the provider in `README.md` and `config/config-example.toml`.
- Add unit tests for the client (request building, hex decoding, API-error handling) and the voice registry.

## Configuration

```toml
[tts]
    provider = "minimax"
    [tts.minimax]
        base_url = ""   # blank → https://api.minimax.io (overseas); use https://api.minimaxi.com for mainland China
        api_key  = ""   # MiniMax API key
        model    = ""   # blank → speech-2.8-hd; also speech-2.8-turbo / speech-2.6-hd / speech-2.6-turbo
```

The API key is read from config; the client also honors the global `[app].proxy` setting.

## Testing

- `go build ./...` passes (including the desktop GUI package).
- `go test ./pkg/minimax/... ./config/... ./internal/voices/...` passes.
- Verified the request shape against the live `/v1/t2a_v2` endpoint (HTTP 200; only blocked by test-account balance, params/auth/model accepted).