### PR TITLE
fix(dubbing): pad dub audio instead of truncating the video tail

### DIFF
--- a/internal/service/dubbing/audio.go
+++ b/internal/service/dubbing/audio.go
@@ -61,9 +61,14 @@ func buildMuxArgs(inputVideo, inputAudio, outputVideo string) []string {
 		"-c:v", "copy",
 		"-map", "0:v:0",
 		"-map", "1:a:0",
+		// apad 生成无限静音，配合 -shortest 使输出恰好等于视频长度。
+		// 只用 -shortest 会让输出在配音音轨结束处截断，丢掉最后一句字幕
+		// 之后的视频内容（片尾、结束画面等）。两个参数必须成对使用，
+		// 单独使用 apad 会无限补静音导致命令不结束。
+		"-af", "apad",
+		"-shortest",
 		"-c:a", "aac",
 		"-b:a", "192k",
-		"-shortest",
 		outputVideo,
 	}
 }

--- a/internal/service/dubbing/audio_test.go
+++ b/internal/service/dubbing/audio_test.go
@@ -53,22 +53,24 @@ func TestBuildMuxArgsMapsVideoAndDubAudio(t *testing.T) {
 func TestBuildMuxArgsPadsAudioInsteadOfTruncatingVideo(t *testing.T) {
 	args := buildMuxArgs("input.mp4", "dub.wav", "out.mp4")
 
-	apad, shortest := -1, -1
+	// 真实约束是 apad 必须作为 -af 的值出现（裸 token 会被 ffmpeg 当成输出文件），
+	// 且 -shortest 必须同时存在。两者在命令行上的先后顺序不影响 ffmpeg 行为：
+	// -af 是滤镜选项，-shortest 是输出选项，作用在不同阶段。
+	afValue, shortest := "", false
 	for i, a := range args {
 		switch a {
-		case "apad":
-			apad = i
+		case "-af":
+			if i+1 < len(args) {
+				afValue = args[i+1]
+			}
 		case "-shortest":
-			shortest = i
+			shortest = true
 		}
 	}
-	if apad == -1 {
-		t.Fatalf("apad filter missing: %v", args)
+	if afValue != "apad" {
+		t.Fatalf("-af should be apad, got %q: %v", afValue, args)
 	}
-	if shortest == -1 {
+	if !shortest {
 		t.Fatalf("-shortest missing: %v", args)
-	}
-	if apad > shortest {
-		t.Fatalf("apad must be applied before -shortest takes effect: %v", args)
 	}
 }

--- a/internal/service/dubbing/audio_test.go
+++ b/internal/service/dubbing/audio_test.go
@@ -43,4 +43,32 @@ func TestBuildMuxArgsMapsVideoAndDubAudio(t *testing.T) {
 	if !strings.Contains(joined, "-shortest") {
 		t.Fatalf("args should include -shortest: %v", args)
 	}
+	// apad 必须与 -shortest 同时存在：只有 -shortest 会截断视频尾部，
+	// 只有 apad 会无限补静音导致 ffmpeg 不退出。
+	if !strings.Contains(joined, "-af apad") {
+		t.Fatalf("args should pad audio with apad so the video tail is not truncated: %v", args)
+	}
+}
+
+func TestBuildMuxArgsPadsAudioInsteadOfTruncatingVideo(t *testing.T) {
+	args := buildMuxArgs("input.mp4", "dub.wav", "out.mp4")
+
+	apad, shortest := -1, -1
+	for i, a := range args {
+		switch a {
+		case "apad":
+			apad = i
+		case "-shortest":
+			shortest = i
+		}
+	}
+	if apad == -1 {
+		t.Fatalf("apad filter missing: %v", args)
+	}
+	if shortest == -1 {
+		t.Fatalf("-shortest missing: %v", args)
+	}
+	if apad > shortest {
+		t.Fatalf("apad must be applied before -shortest takes effect: %v", args)
+	}
 }


### PR DESCRIPTION
## Problem

`buildMuxArgs` (`internal/service/dubbing/audio.go:56`) passes `-shortest` with no audio padding:

```go
"-map", "1:a:0",
"-c:a", "aac",
"-b:a", "192k",
"-shortest",
```

`-shortest` ends the output when the shortest input ends. The dubbed audio track is assembled from the subtitle plan (`AssembleAudio` / `AssembleChunkAudio`), so it stops at the last cue. Any video after the final spoken line — outro, end card, closing shot, trailing silence — is dropped from the final file.

The failure is silent: ffmpeg exits 0, the output plays fine, and nothing in the logs mentions a duration change. How much is lost depends on the gap between the last cue and the end of the video, so it varies per input.

## Reproduction

A 60 s video whose last subtitle ends at 50 s:

```console
$ ffmpeg -v error -y -f lavfi -i "testsrc=size=320x240:rate=30:duration=60" \
    -c:v libx264 -pix_fmt yuv420p video.mp4
$ ffmpeg -v error -y -f lavfi -i "anullsrc=r=44100:cl=mono" -t 50 -c:a pcm_s16le dub.wav

$ ffmpeg -v error -y -i video.mp4 -i dub.wav -c:v copy -map 0:v:0 -map 1:a:0 \
    -c:a aac -b:a 192k -shortest out.mp4
$ ffprobe -v error -show_entries format=duration -of csv=p=0 out.mp4
50.000000
```

60 s in, 50 s out.

## Fix

Add `-af apad` so the audio is padded with silence, letting `-shortest` stop at the end of the video instead:

| args | output duration |
| --- | --- |
| `-shortest` alone (current) | 50.000 s |
| `-af apad -shortest` (this PR) | 60.000 s |

Verified end-to-end by calling the patched `buildMuxArgs` through real ffmpeg: output is 60.000 s with the audio stream padded to 59.977 s, AAC as before.

The two flags must stay paired — `apad` alone pads indefinitely and ffmpeg never exits. I noted that in a comment and added a test asserting both are present, so they do not get separated later.

## Testing

- `go build ./...` clean
- `go vet ./internal/service/dubbing/` clean
- `gofmt` clean
- `go test ./internal/service/dubbing/` passes, including the existing `TestBuildMuxArgsMapsVideoAndDubAudio` (its `-shortest` assertion still holds) plus a new `TestBuildMuxArgsPadsAudioInsteadOfTruncatingVideo`

Environment: go1.26.5 darwin/arm64, ffmpeg 8.1.1.

## Note

`Test_splitOriginLongSentence` in `internal/service` fails on master for me because it needs an OpenAI API key — unrelated to this change, and it fails identically with the patch stashed.