### PR TITLE
fix(subtitle): count runes not bytes when splitting short subtitles

### DIFF
--- a/internal/service/youtube_subtitle.go
+++ b/internal/service/youtube_subtitle.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"krillin-ai/config"
 	"krillin-ai/internal/storage"
@@ -3297,7 +3298,11 @@ func (s *YouTubeSubtitleService) groupWordsByCharLength(words []VttWord, maxChar
 	currentLength := 0
 
 	for _, word := range words {
-		wordLen := len(word.Text)
+		// 按字符数而非字节数计算：len() 对非 ASCII 返回字节数，
+		// 会让日语/韩语/俄语/阿拉伯语等源语言的实际行长上限缩到
+		// maxChars 的 1/2 ~ 1/4，字幕被切成碎片。
+		// 对 ASCII 两者相同，英文行为不变。
+		wordLen := utf8.RuneCountInString(word.Text)
 
 		// 计算加上这个单词后的总长度（包含空格）
 		newLength := currentLength

--- a/internal/service/youtube_subtitle_fix_test.go
+++ b/internal/service/youtube_subtitle_fix_test.go
@@ -1,6 +1,7 @@
 package service
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -110,6 +111,57 @@ func TestGroupWordsByCharLengthMergesShortTrailingWord(t *testing.T) {
 	}
 	if got := groups[0][len(groups[0])-1].Text; got != "scrolling," {
 		t.Fatalf("last word = %q, want scrolling,", got)
+	}
+}
+
+// 非 ASCII 源语言必须按字符数分组。按字节数会把这些语言的字幕切成碎片：
+// 「日本語」3 个字符占 9 字节，maxChars=20 时按字节只能放 2 个词。
+func TestGroupWordsByCharLengthCountsRunesNotBytes(t *testing.T) {
+	s := &YouTubeSubtitleService{}
+
+	cases := []struct {
+		name  string
+		words []string
+		want  int
+	}{
+		{
+			name:  "japanese",
+			words: []string{"これは", "日本語", "の", "字幕", "です"},
+			want:  1, // 12 字符 <= 20，应保持一行
+		},
+		{
+			// 尾组两个词，避免被 mergeShortTrailingWordGroup 合并回去。
+			// 按字符共 32 个 -> 2 组；按字节共 59 个 -> 4 组。
+			name:  "russian",
+			words: []string{"быстрая", "коричневая", "лиса", "прыгает"},
+			want:  2,
+		},
+		{
+			name:  "ascii unchanged",
+			words: []string{"the", "quick", "brown", "fox"},
+			want:  1, // 17 字符 <= 20
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			words := make([]VttWord, 0, len(tc.words))
+			for _, w := range tc.words {
+				words = append(words, VttWord{Text: w, Start: "00:00:00.000", End: "00:00:01.000"})
+			}
+			groups := s.groupWordsByCharLength(words, 20)
+			if len(groups) != tc.want {
+				var got []string
+				for _, g := range groups {
+					var seg []string
+					for _, w := range g {
+						seg = append(seg, w.Text)
+					}
+					got = append(got, strings.Join(seg, " "))
+				}
+				t.Fatalf("group count = %d, want %d; groups = %v", len(groups), tc.want, got)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Problem

`groupWordsByCharLength` (`internal/service/youtube_subtitle.go:3300`) measures word length in bytes:

```go
for _, word := range words {
    wordLen := len(word.Text)   // bytes, not characters
```

For ASCII that equals the character count, so English source audio behaves correctly — which is what the surrounding comment describes (`生成短字幕文件（中文完整 + 英文拆分）`).

But the source language is not restricted to English. `internal/types/language.go` lists Japanese, Korean, Russian, Arabic, Hindi, Bengali, Hebrew, Persian, Greek, Ukrainian, Thai and more, and `writeShortSubtitleFile` splits whatever the origin-language words are. For those scripts each character costs 2–4 bytes, so the effective limit becomes a fraction of the configured `short_subtitle_max_chars` (default 20).

## Effect

Simulating the loop at lines 3300–3318 with `maxChars = 20`:

| source language | groups now (bytes) | groups with rune count | over-split by |
| --- | --- | --- | --- |
| English | 2 | 2 | — |
| Russian | 3 | 2 | 1 extra cut |
| Japanese | 3 | 1 | 2 extra cuts |
| Hindi | 5 | 2 | 3 extra cuts |

Per-word cost:

| word | bytes | characters |
| --- | --- | --- |
| `fox` | 3 | 3 |
| `лиса` | 8 | 4 |
| `日本語` | 9 | 3 |
| `हिंदी` | 15 | 5 |

On vertical video — the case this function exists for — a Hindi line that should occupy one row becomes three separate subtitle blocks.

## The codebase already counts runes elsewhere

`wordGroupTextLength`, 50 lines below in the same file (line 3354), uses `len([]rune(word.Text))`, and `util.CountEffectiveChars` (`pkg/util/subtitle.go:523`) does the same. So `maxChars` currently means two different things depending on the code path.

## Fix

```go
wordLen := utf8.RuneCountInString(word.Text)
```

Plus the `unicode/utf8` import. Output for ASCII source audio is byte-for-byte unchanged, since rune count and byte count agree there.

## Testing

- `go build ./...` clean
- `go vet ./internal/service/` clean
- `gofmt` clean
- Existing `TestGroupWordsByCharLengthMergesShortTrailingWord` still passes (ASCII only, unaffected)
- Added `TestGroupWordsByCharLengthCountsRunesNotBytes` covering Japanese, Russian and an ASCII regression case

I verified the new test actually catches the bug: reverting to `len(word.Text)` (and dropping the import) makes the Japanese case fail with `group count = 2, want 1` and the Russian case with `group count = 3, want 2`.

Environment: go1.26.5 darwin/arm64.

## Out of scope

For languages without inter-word spaces (Japanese, Thai, or Chinese *as a source* language), whether `VttWord` tokens plus the `+1` space accounting at line 3305 is the right splitting model at all is a separate question. This PR only makes the limit mean what its name says.

## Note

`Test_splitOriginLongSentence` in the same package fails on master for me because it needs an OpenAI API key — unrelated to this change, and it fails identically with the patch stashed.